### PR TITLE
Dispatch button action if it's FSAish

### DIFF
--- a/src/components/Snackbar/Snackbar.js
+++ b/src/components/Snackbar/Snackbar.js
@@ -88,6 +88,8 @@ class Snackbar extends React.Component {
 			onButtonClick(snack);
 		} else if (button.action && typeof button.action === 'function') {
 			button.action(snack);
+		} else if (button.action && typeof button.action.type === 'string') {
+			this.props.dispatch(button.action);
 		} else if (button.action === 'redirect' && button.href) {
 			window.location.href = button.href;
 		}


### PR DESCRIPTION
This PR allows you to dispatch a button action if it is somewhat FSA-compliant.

Example: 
```js
dispatch(showSnack('myUniqueId', {
  label: 'Entry removed',
  timeout: 7000,
  button: { 
    label: 'UNDO', 
    action: { 
      type: 'UNDO_REMOVE', 
      payload: { entryId: '123' }
    } 
  }
});
```